### PR TITLE
Add 'web' feature to spawn tasks using wasm_bndget_futures::spawn_local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: cargo clippy
         run: |
           rustup component add clippy
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets --features "tokio" -- -D warnings
 
   test:
     name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `web` feature to enable `Promise::spawn_async` using [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
+
 
 ## [0.1.0] - 2022-01-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit - add the `Promise` type.
 
-[Unreleased]: https://github.com/EmbarkStudios/poll-promise/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/poll-promise/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/EmbarkStudios/poll-promise/releases/tag/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["tokio"]
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ all-features = true
 static_assertions = "1.1"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
+
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+
+[features]
+# Allow spawning a task when running in a web browser.
+web = ["wasm-bindgen", "wasm-bindgen-futures"]

--- a/check.sh
+++ b/check.sh
@@ -6,14 +6,12 @@ set -eux
 # Checks all tests, lints etc.
 # Basically does what the CI does.
 
-cargo check --workspace --all-targets
-cargo test --workspace --doc
-cargo check --workspace --all-targets --all-features
-cargo check --target wasm32-unknown-unknown
-cargo check --target wasm32-unknown-unknown --all-features
-cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::all
-cargo test --workspace --all-targets --all-features
+cargo check --workspace --all-targets --features "tokio"
+cargo check --target wasm32-unknown-unknown --features "web"
+cargo test --workspace --doc --features "tokio"
+cargo test --workspace --all-targets --features "tokio"
+cargo clippy --workspace --all-targets --features "tokio" -- -D warnings -W clippy::all
 cargo fmt --all -- --check
 
-cargo doc --no-deps --all-features
-cargo doc --target wasm32-unknown-unknown --no-deps --all-features
+cargo doc --no-deps --features "tokio"
+# cargo doc --target wasm32-unknown-unknown --no-deps --features "web"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@
 //! which will spawn tasks in the surrounding tokio runtime.
 //!
 //! ### `web`
-//! If you enable the `web` feature you can use [`Promise::spawn_async`] and [`Promise::spawn_blocking`]
-//! which will spawn tasks using [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
+//! If you enable the `web` feature you can use [`Promise::spawn_async`] which will spawn tasks using
+//! [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
 
 // BEGIN - Embark standard lints v5 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,17 @@
 //! }
 //! ```
 //!
-//! If you enable the `tokio` feature you can use `poll-promise` with the [tokio](https://github.com/tokio-rs/tokio)
-//! runtime to run `async` tasks using [`Promise::spawn_async`] and [`Promise::spawn_blocking`].
+//! ## Features
+//! `poll-promise` can be used with any async runtime, but a few convenience methods are added
+//! when compiled with the following features:
+//!
+//! ### `tokio`
+//! If you enable the `tokio` feature you can use [`Promise::spawn_async`] and [`Promise::spawn_blocking`]
+//! which will spawn tasks in the surrounding tokio runtime.
+//!
+//! ### `web`
+//! If you enable the `web` feature you can use [`Promise::spawn_async`] and [`Promise::spawn_blocking`]
+//! which will spawn tasks using [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
 
 // BEGIN - Embark standard lints v5 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This enables `spawn_async` ~and `spawn_blocking`~ when compiling for web.

### Related Issues
