### PR TITLE
Allow non Send futures on wasm

### DIFF
--- a/src/promise.rs
+++ b/src/promise.rs
@@ -48,6 +48,9 @@ pub struct Promise<T: Send + 'static> {
     data: PromiseImpl<T>,
 }
 
+#[cfg(all(feature = "tokio", feature = "web"))]
+compile_error!("You cannot specify both the 'tokio' and 'web' feature");
+
 // Ensure that Promise is !Sync, confirming the safety of the unsafe code.
 static_assertions::assert_not_impl_all!(Promise<u32>: Sync);
 static_assertions::assert_impl_all!(Promise<u32>: Send);
@@ -105,11 +108,11 @@ impl<T: Send + 'static> Promise<T> {
     /// let promise = Promise::spawn_async(async move { something_async().await });
     /// ```
     #[cfg(any(feature = "tokio", feature = "web"))]
-    pub fn spawn_async(future: impl std::future::Future<Output = T> + 'static + Send) -> Self {
+    pub fn spawn_async(
+        #[cfg(feature = "tokio")] future: impl std::future::Future<Output = T> + 'static + Send,
+        #[cfg(feature = "web")] future: impl std::future::Future<Output = T> + 'static,
+    ) -> Self {
         let (sender, promise) = Self::new();
-
-        #[cfg(all(feature = "tokio", feature = "web"))]
-        compile_error!("You cannot specify both the 'tokio' and 'web' feature");
 
         #[cfg(feature = "tokio")]
         {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Added attributes in the function parameters for `Promise::spawn_async` to enable/disable the `Send` trait bound

Without this patch calling an async function like this one using poll promise would not compile

```rs
#[wasm_bindgen(module = "/assets/filesystem.js")]
extern "C" {
    #[wasm_bindgen(catch)]
    async fn js_open_project() -> Result<JsValue, JsValue>;
    #[wasm_bindgen(catch)]
    async fn js_read_file(handle: JsValue, _path: String) -> Result<JsValue, JsValue>;
    fn js_filesystem_supported() -> bool;
}

/* ... */

pub async fn try_open_project(&self, cache: Arc<DataCache>) -> Result<(), String> {
    let handle = js_open_project()
        .await
        .map_err(|_| "No project loaded".to_string())?;

    self.load_project(handle, cache)
}
```
![image](https://user-images.githubusercontent.com/54482069/193502619-e4de1ce8-2fe9-4682-a446-adbce1c59551.png)

It'd make sense to remove the `Send` limitation specifically for web since I'd imagine people using this crate for wasm are likely operating with async JS functions

https://github.com/Speak2Erase/poll-promise/blob/bfc32879452afea0f2eec6355e40ec4de05c8c92/src/promise.rs#L112-L113

### Related Issues

Fixes #8 