### PR TITLE
Support smol as an executor and add Promise::spawn_local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,10 @@ jobs:
         # faster test execution time. If you don't have any heavy tests it
         # might be faster to take off release and just compile in debug
         run: cargo build --tests --release
-      - name: cargo test
-        run: cargo test --release
+      - name: cargo test smol
+        run: cargo test --release -F smol -F tick-poll
+      - name: cargo test tokio
+        run cargo test --release -F tokio
 
   # TODO: Remove this check if you don't use cargo-deny in the repo
   deny-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: cargo test smol
         run: cargo test --release -F smol -F tick-poll
       - name: cargo test tokio
-        run cargo test --release -F tokio
+        run: cargo test --release -F tokio
 
   # TODO: Remove this check if you don't use cargo-deny in the repo
   deny-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         # might be faster to take off release and just compile in debug
         run: cargo build --tests --release
       - name: cargo test smol
-        run: cargo test --release -F smol -F tick-poll
+        run: cargo test --release -F smol -F smol_tick_poll
       - name: cargo test tokio
         run: cargo test --release -F tokio
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": ["smol"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.cargo.features": ["smol"]
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor `Promise::spawn_async` into two new functions, `Promise::spawn_async` and `Promise::spawn_local`
 - `smol_tick_poll` feature to automatically tick the smol executor when polling promises
 
-## [0.2.0] - 2022-01-10
+## [0.2.0] - 2022-10-25
 ### Added
 - `web` feature to enable `Promise::spawn_async` using [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
 - Add `Promise::abort` to abort the associated async task, if any.
@@ -21,5 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial commit - add the `Promise` type.
 
 [Unreleased]: https://github.com/EmbarkStudios/poll-promise/compare/0.2.0...HEAD
-[0.1.0]: https://github.com/EmbarkStudios/poll-promise/releases/tag/0.2.0
+[0.2.0]: https://github.com/EmbarkStudios/poll-promise/releases/tag/0.2.0
 [0.1.0]: https://github.com/EmbarkStudios/poll-promise/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- `smol` feature to enable the use of [`smol`](https://github.com/smol-rs/smol)
+- refactor `Promise::spawn_async` into two new functions, `Promise::spawn_async` and `Promise::spawn_local`
+- `smol_tick_poll` feature to automatically tick the smol executor when polling promises
 
 ## [0.2.0] - 2022-01-10
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,13 @@ features = ["tokio", "smol"]
 [dependencies]
 static_assertions = "1.1"
 smol =  { version = "1.2.5", optional =  true }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"], optional = true }
 
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
+
+[dev-dependencies]
+async-net = "1.7.0"
 
 [features]
 # Allow spawning a task when running in a web browser.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,4 @@ async-net = "1.7.0"
 [features]
 # Allow spawning a task when running in a web browser.
 web = ["wasm-bindgen", "wasm-bindgen-futures"]
-tick-poll = []
+smol_tick_poll = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-features = ["tokio"]
+features = ["tokio", "smol"]
 
 [lib]
 
 [dependencies]
 static_assertions = "1.1"
-
-tokio = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
+smol =  { version = "1.2.5", optional =  true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"], optional = true }
 
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
@@ -33,3 +33,4 @@ wasm-bindgen-futures = { version = "0.4", optional = true }
 [features]
 # Allow spawning a task when running in a web browser.
 web = ["wasm-bindgen", "wasm-bindgen-futures"]
+tick-poll = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,13 @@
 //! ### `smol_tick_poll`
 //! Enabling the `smol_tick_poll` with `smol` calling [`Promise::poll`] will automatically tick the smol executor.
 //! This means you do not have to worry about calling [`tick`] but comes at the cost of loss of finer control over the executor.
-//! 
+//!
 //! Since calling [`tick_local`] will block the current thread, running multiple local promises at once with `smol_tick_poll` enabled
 //! may also cause stuttering.
-//! 
-//! poll-promise will automatically tick the smol executor with this feature disabled for you when using [`Promise::block_until_ready`] 
+//!
+//! poll-promise will automatically tick the smol executor with this feature disabled for you when using [`Promise::block_until_ready`]
 //! and friends, however.
-//! 
+//!
 
 // BEGIN - Embark standard lints v6 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@
 //! when compiled with the following features:
 //!
 //! ### `tokio`
-//! If you enable the `tokio` feature you can use [`Promise::spawn_async`] and [`Promise::spawn_blocking`]
+//! If you enable the `tokio` feature you can use [`Promise::spawn_async`], [`Promise::spawn_local`] and [`Promise::spawn_blocking`]
 //! which will spawn tasks in the surrounding tokio runtime.
 //!
 //! ### `web`
-//! If you enable the `web` feature you can use [`Promise::spawn_async`] which will spawn tasks using
+//! If you enable the `web` feature you can use [`Promise::spawn_local`] which will spawn tasks using
 //! [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).
 
 // BEGIN - Embark standard lints v6 for Rust 1.55+

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -188,7 +188,7 @@ impl<T: Send + 'static> Promise<T> {
         #[cfg(feature = "tokio")]
         {
             promise.join_handle = Some(tokio::task::spawn_local(async move {
-                sender.send(future.await)
+                sender.send(future.await);
             }));
         }
 

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -367,7 +367,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
     fn poll_mut(&mut self, task_type: TaskType) -> std::task::Poll<&mut T> {
         match self {
             Self::Pending(rx) => {
-                #[cfg(all(feature = "smol", feature = "tick-poll"))]
+                #[cfg(all(feature = "smol", feature = "smol_tick_poll"))]
                 Self::tick(task_type);
                 if let Ok(value) = rx.try_recv() {
                     *self = Self::Ready(value);
@@ -402,7 +402,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
     fn poll(&self, task_type: TaskType) -> std::task::Poll<&T> {
         match self {
             Self::Pending(rx) => {
-                #[cfg(all(feature = "smol", feature = "tick-poll"))]
+                #[cfg(all(feature = "smol", feature = "smol_tick_poll"))]
                 Self::tick(task_type);
                 match rx.try_recv() {
                     Ok(value) => {
@@ -435,7 +435,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
         #[cfg(feature = "smol")]
         while self.poll(task_type).is_pending() {
             // Tick unless poll does it for us.
-            #[cfg(not(feature = "tick-poll"))]
+            #[cfg(not(feature = "smol_tick_poll"))]
             Self::tick(task_type);
         }
         match self {
@@ -458,7 +458,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
         #[cfg(feature = "smol")]
         while self.poll(task_type).is_pending() {
             // Tick unless poll does it for us.
-            #[cfg(not(feature = "tick-poll"))]
+            #[cfg(not(feature = "smol_tick_poll"))]
             Self::tick(task_type);
         }
         match self {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Smol is now a supported executor. With it comes two new functions:
```rs
// Ticks the smol thread executor
poll_promise::tick();
// Ticks the thread local smol executor
poll_promise::tick_local();
```
They should be used in an update loop when not using the `tick-poll` feature.
```rs
loop {
  // game logic code here

  // push a frame

  // tick executor
  poll_promise::tick();
}
```

 - These tick static variables provided by the crate `EXECUTOR` and `LOCAL_EXECUTOR` resepectively
 - Blocking on promises now loops and constantly polls them instead of waiting on the receiver
 - Blocking also automatically ticks for you
 - The `tick-poll` feature automatically ticks the executors when polling promises like when blocking

Promises now have a field called `task_type` which stores the type of task the promise is running (`TaskType::Local` for local tasks, `TaskType::Async` for async tasks, etc)
They are used primarily for determining what executor to tick when blocking (or polling)

There are now tests in `lib.rs`
```rs
    fn it_spawns_threads() {
        let promise = Promise::spawn_thread("test", || {
            std::thread::sleep(std::time::Duration::from_secs(1));
            0
        });

        assert_eq!(0, promise.block_and_take());
    }
```  

- `Promise::spawn_async` has been split into `Promise::spawn_local` to run futures locally
- `Promise::spawn_async` is no longer usable on wasm and `spawn_local` must be used instead
- 
Tokio does not play very well with `spawn_local` though, there doesn't seem to be much this library could do about that without forcing a `Send` bound onto `spawn_local` 

### Related Issues

Helps further resolve #8 and makes `poll_promise` more usable on the web and on native
