### PR TITLE
Fix undefined behavior by introducing use of  `UnsafeCell`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor `Promise::spawn_async` into two new functions, `Promise::spawn_async` and `Promise::spawn_local`
 - `smol_tick_poll` feature to automatically tick the smol executor when polling promises
 
+### Fixed
+- Undefined behavior in `PromiseImpl::poll` and `PromiseImpl::block_until_ready`
+
 ## [0.2.0] - 2022-10-25
 ### Added
 - `web` feature to enable `Promise::spawn_async` using [`wasm_bindgen_futures::spawn_local`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html).


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Mutating through a shared reference without an `UnsafeCell` is UB. From the `UnsafeCell` docs:

> If you have a reference &T, then normally in Rust the compiler performs optimizations based on the knowledge that &T points to immutable data. Mutating that data, for example through an alias or by transmuting an &T into an &mut T, is considered undefined behavior.

```rust
unsafe {
      let myself = self as *const Self as *mut Self;
      *myself = Self::Ready(value);
}
```
^ is thus UB

