### PR TITLE
Support async-std as an executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         run: cargo test --release -F smol -F smol_tick_poll
       - name: cargo test tokio
         run: cargo test --release -F tokio
+      - name: cargo test async-std
+        run: cargo test --release -F async-std
 
   # TODO: Remove this check if you don't use cargo-deny in the repo
   deny-check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ features = ["tokio", "smol"]
 static_assertions = "1.1"
 smol =  { version = "1.2.5", optional =  true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"], optional = true }
+async-std = { version = "1.12", optional = true }
 
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ keywords = ["promise", "poll", "async", "gamedev", "gui"]
 include = ["LICENSE-APACHE", "LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [package.metadata.docs.rs]
-features = ["tokio", "smol"]
+features = ["tokio", "smol", "async-std"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ deny = [
 skip = [
 ]
 skip-tree = [
+    { name = "async-io", version = "<= 1.12.0" }
 ]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@
 //! poll-promise will automatically tick the smol executor with this feature disabled for you when using [`Promise::block_until_ready`]
 //! and friends, however.
 //!
+//! ### `async-std`
+//! If you enable the `async-std` feature you can use [`Promise::spawn_async`] and [`Promise::spawn_blocking`]
+//! which will spawn tasks in the surrounding async-std runtime.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // BEGIN - Embark standard lints v6 for Rust 1.55+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 //! and friends, however.
 //!
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // BEGIN - Embark standard lints v6 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,14 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "async-std")]
+    fn it_runs_async_threaded() {
+        let promise = Promise::spawn_async(async move { 0 });
+
+        assert_eq!(0, promise.block_and_take());
+    }
+
+    #[test]
     #[cfg(feature = "smol")]
     fn it_runs_locally() {
         let promise = Promise::spawn_local(async move { 0 });
@@ -219,6 +227,21 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "tokio")]
     async fn it_runs_background() {
+        let promise = Promise::spawn_async(async move {
+            let mut e = 0;
+            for i in -10000..0 {
+                e += i;
+            }
+            e
+        });
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert!(promise.ready().is_some(), "was not finished");
+    }
+
+    #[test]
+    #[cfg(feature = "async-std")]
+    fn it_runs_background() {
         let promise = Promise::spawn_async(async move {
             let mut e = 0;
             for i in -10000..0 {
@@ -261,6 +284,14 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "async-std")]
+    fn it_can_run_async_functions() {
+        let promise = Promise::spawn_async(async move { something_async().await });
+
+        assert!(promise.block_and_take(), "example.com is ipv4");
+    }
+
+    #[test]
     #[cfg(feature = "smol")]
     fn it_can_run_async_functions_locally() {
         let promise = Promise::spawn_local(async move { something_async().await });
@@ -270,7 +301,7 @@ mod test {
         assert!(promise.block_and_take(), "example.com is ipv4");
     }
 
-    #[cfg(any(feature = "smol", feature = "tokio"))]
+    #[cfg(any(feature = "smol", feature = "tokio", feature = "async-std"))]
     async fn something_async() -> bool {
         async_net::resolve("example.com:80").await.unwrap()[0].is_ipv4()
     }

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -72,8 +72,17 @@ pub struct Promise<T: Send + 'static> {
     join_handle: Option<async_std::task::JoinHandle<()>>,
 }
 
-#[cfg(all(feature = "tokio", feature = "web"))]
-compile_error!("You cannot specify both the 'tokio' and 'web' feature");
+#[cfg(any(
+    all(feature = "tokio", feature = "smol"),
+    all(feature = "tokio", feature = "async-std"),
+    all(feature = "tokio", feature = "web"),
+    all(feature = "smol", feature = "async-std"),
+    all(feature = "smol", feature = "web"),
+    all(feature = "async-std", feature = "web"),
+))]
+compile_error!(
+    "You can only specify one of the executor features: 'tokio', 'smol', 'async-std' or 'web'"
+);
 
 // Ensure that Promise is !Sync, confirming the safety of the unsafe code.
 static_assertions::assert_not_impl_all!(Promise<u32>: Sync);


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
This PR adds support for the async-std executor.
It also fixed the feature exclusivity check to include all combinations of executor features.

I'm using poll-promise in combination with async-std in my [egui-y GUI for magic-wormhole](https://github.com/bash/portal). One of my dependencies brings in async-std, so to avoid bloating my app with another executor I decided to also use async-std.