### PR TITLE
Use async-executor instead of smol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         # faster test execution time. If you don't have any heavy tests it
         # might be faster to take off release and just compile in debug
         run: cargo build --tests --release
-      - name: cargo test smol
-        run: cargo test --release -F smol -F smol_tick_poll
+      - name: cargo test async-executor
+        run: cargo test --release -F async-executor -F async_executor_tick_poll
       - name: cargo test tokio
         run: cargo test --release -F tokio
       - name: cargo test async-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["promise", "poll", "async", "gamedev", "gui"]
 include = ["LICENSE-APACHE", "LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [package.metadata.docs.rs]
-features = ["tokio", "smol", "async-std"]
+features = ["tokio", "async_executor", "async-std"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 
 [dependencies]
 static_assertions = "1.1"
-smol =  { package = "async-executor", version = "1.2.5", optional =  true }
+async-executor = { version = "1.5.0", optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"], optional = true }
 async-std = { version = "1.12", optional = true }
 
@@ -33,4 +33,4 @@ async-net = "1.7.0"
 [features]
 # Allow spawning a task when running in a web browser.
 web = ["wasm-bindgen", "wasm-bindgen-futures"]
-smol_tick_poll = []
+async_executor_tick_poll = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 static_assertions = "1.1"
-smol =  { version = "1.2.5", optional =  true }
+smol =  { package = "async-executor", version = "1.2.5", optional =  true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"], optional = true }
 async-std = { version = "1.12", optional = true }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Replaces `smol` with the `async-executor` crate, so that this crate doesn't import all of `smol` just for the executor.

### Related Issues

N/A
