### PR TITLE
Disable blocking functions in wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
+- Disable all blocking functions on Wasm, since you are not allowed to block in a browser
 
 
 ## [0.3.0] - 2023-08-27
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2022-01-10
 ### Added
 - Initial commit - add the `Promise` type.
+
 
 [Unreleased]: https://github.com/EmbarkStudios/poll-promise/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/EmbarkStudios/poll-promise/releases/tag/0.3.0

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -347,6 +347,7 @@ impl<T: Send + 'static> Promise<T> {
     /// Block execution until ready, then returns a reference to the value.
     ///
     /// Panics if the connected [`Sender`] was dropped before a value was sent.
+    #[cfg(not(target_arch = "wasm32"))] // Not allowed to block on Wasm
     pub fn block_until_ready(&self) -> &T {
         self.data.block_until_ready(self.task_type)
     }
@@ -354,6 +355,7 @@ impl<T: Send + 'static> Promise<T> {
     /// Block execution until ready, then returns a mutable reference to the value.
     ///
     /// Panics if the connected [`Sender`] was dropped before a value was sent.
+    #[cfg(not(target_arch = "wasm32"))] // Not allowed to block on Wasm
     pub fn block_until_ready_mut(&mut self) -> &mut T {
         self.data.block_until_ready_mut(self.task_type)
     }
@@ -361,6 +363,7 @@ impl<T: Send + 'static> Promise<T> {
     /// Block execution until ready, then returns the promised value and consumes the `Promise`.
     ///
     /// Panics if the connected [`Sender`] was dropped before a value was sent.
+    #[cfg(not(target_arch = "wasm32"))] // Not allowed to block on Wasm
     pub fn block_and_take(self) -> T {
         self.data.block_until_ready(self.task_type);
         match self.data.0.into_inner() {
@@ -481,6 +484,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
     }
 
     #[allow(unused_variables)]
+    #[cfg(not(target_arch = "wasm32"))] // Not allowed to block on Wasm
     fn block_until_ready_mut(&mut self, task_type: TaskType) -> &mut T {
         // Constantly poll until we're ready.
         #[cfg(feature = "smol")]
@@ -505,6 +509,7 @@ impl<T: Send + 'static> PromiseImpl<T> {
 
     #[allow(unsafe_code)]
     #[allow(unused_variables)]
+    #[cfg(not(target_arch = "wasm32"))] // Not allowed to block on Wasm
     fn block_until_ready(&self, task_type: TaskType) -> &T {
         // Constantly poll until we're ready.
         #[cfg(feature = "smol")]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Disable all blocking functions in Wasm, since you are not allowed to block the execution in a browser, and doing so causes a panic.

### Related Issues

* Closes https://github.com/EmbarkStudios/poll-promise/issues/17